### PR TITLE
Implement message checkout and mobile display

### DIFF
--- a/packages/frontend/src/components/block/chat/checkout-button.tsx
+++ b/packages/frontend/src/components/block/chat/checkout-button.tsx
@@ -1,0 +1,29 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import LucideUndo2 from "~icons/lucide/undo-2";
+
+interface CheckoutButtonProps {
+  onCheckout: () => void;
+  isVisible: boolean;
+  className?: string;
+}
+
+export function CheckoutButton({ onCheckout, isVisible, className }: CheckoutButtonProps) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={onCheckout}
+      className={cn(
+        "transition-opacity duration-200 text-xs underline decoration-1 underline-offset-2 hover:decoration-2 text-muted-foreground hover:text-foreground",
+        "opacity-100 md:opacity-0 md:group-hover:opacity-100", // Always visible on mobile, hidden on desktop until hover
+        isVisible && "md:opacity-100", // Show when explicitly visible
+        className
+      )}
+      aria-label="Checkout this message"
+    >
+      <LucideUndo2 className="size-3 mr-1" />
+      Checkout
+    </Button>
+  );
+}

--- a/packages/frontend/src/components/block/chat/user-message.tsx
+++ b/packages/frontend/src/components/block/chat/user-message.tsx
@@ -1,24 +1,45 @@
 import { Separator } from "@/components/ui/separator";
 import type { IMessageRequest } from "@/sdk/shared";
 import Markdown from "react-markdown";
+import { CheckoutButton } from "./checkout-button";
+import { useState } from "react";
 
 export function UserMessage({
   sessionId,
   messageId,
   messages,
+  onCheckout,
 }: {
   sessionId: string;
   messageId: string;
   messages: IMessageRequest[];
+  onCheckout?: () => void;
 }) {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const messageContent = messages
+    .filter((message) => message.type === "text")
+    .map((message) => message.text)
+    .join("\n");
+
+  const handleCheckout = () => {
+    if (onCheckout) {
+      onCheckout();
+    }
+  };
+
   return (
-    <div className="flex flex-col items-end gap-2 w-full">
+    <div 
+      className="flex flex-col items-end gap-2 w-full group"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
       <Separator className="relative mb-2">
         <div className="bg-background dark:bg-background rounded-md px-2 absolute right-4 inset-y-0 flex flex-row justify-end items-center gap-1">
           <span className="text-sm text-muted-foreground">User</span>
         </div>
       </Separator>
-      <div className="flex flex-col items-end justify-start prose dark:prose-invert w-full max-w-full">
+      <div className="flex flex-col items-end justify-start prose dark:prose-invert w-full max-w-full relative">
         {messages.map((message, index) => {
           if (message.type === "text") {
             return (
@@ -28,6 +49,14 @@ export function UserMessage({
             );
           }
         })}
+        {onCheckout && (
+          <div className="absolute top-0 right-0 -translate-y-8">
+            <CheckoutButton
+              onCheckout={handleCheckout}
+              isVisible={isHovered}
+            />
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Add a 'checkout' feature to user messages, allowing users to restore a message to the textarea and delete subsequent conversation.

---
<a href="https://cursor.com/background-agent?bcId=bc-4b9351d8-39b8-4e11-8cab-1f15e46092a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4b9351d8-39b8-4e11-8cab-1f15e46092a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>